### PR TITLE
fix: 修复 gemma-4-31b-it 模型识别结果异常

### DIFF
--- a/CAPTCHA-automatic-recognition/src/app.vue
+++ b/CAPTCHA-automatic-recognition/src/app.vue
@@ -1043,13 +1043,13 @@ export default {
             {
               parts: [
                 {
-                  text: prompt,
-                },
-                {
                   inline_data: {
                     mime_type: "image/png",
                     data: base64Image,
                   },
+                },
+                {
+                  text: prompt,
                 },
               ],
             },
@@ -1062,22 +1062,21 @@ export default {
           "Content-Type": "application/json",
         },
       });
-
-      // 提取结果
-      if (response.data.candidates && response.data.candidates.length > 0) {
-        const candidate = response.data.candidates[0];
-        if (
-          candidate.content &&
-          candidate.content.parts &&
-          candidate.content.parts.length > 0
-        ) {
-          const text = candidate.content.parts[0].text || "";
-          // 只保留数字、字母和负号
-          return text.replace(/[^a-zA-Z0-9\-]/g, "");
+      const parts = response?.data?.candidates?.[0]?.content?.parts;
+      if (!Array.isArray(parts) || parts.length === 0) {
+        return "";
+      }
+      let fullText = "";
+      for (const part of parts) {
+        if (typeof part?.text === "string" && part.text && !part.thought) {
+          fullText += part.text;
         }
       }
-
-      return "";
+      if (!fullText) {
+        return "";
+      }
+      const cleanText = fullText.replace(/<think>[\s\S]*?<\/think>/gi, "");
+      return cleanText.replace(/[^a-zA-Z0-9\-]/g, "");
     },
 
     /**


### PR DESCRIPTION
## 变更说明

重写 `recognizeWithGemini` 识别函数，修复 `gemma-4-31b-it` 模型可用性


## 修改原因

原函数无法正确处理 `gemma-4-31b-it` 模型返回结果，会将整段思考内容一并返回，如：

```text
TheuserwantsmetoactasaSeniorCaptchaRecognitionExpertTheimagecontainspinkcharactersonawhitebackgroundThecharactersare6675Theprompthasverystrictoutputrules1NoEnglishpromptsexplanations2Onlyoutputtheresult3Ifthinkingisneededitmustbein100ChineseImageanalysis-Firstcharacter6-Secondcharacter6-Thirdcharacter7-Fourthcharacter5Result6675
```

重写后可以正确清洗结果为 `6675`


## 影响范围

- Gemini 验证码识别流程


## 验证情况

本地测试 `gemma-4-31b-it`、`gemini-2.5-flash-lite` 模型皆工作正常，未破坏原有兼容性